### PR TITLE
Add module-tier properties for `default` and `lenient`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const lenient = require('./lenient');
 module.exports = (val, opts) => {
 	val = String(val).trim();
 	opts = Object.assign({
-		lenient: false,
-		default: null
+		lenient: module.exports.lenient,
+		default: module.exports.default
 	}, opts);
 
 	if (opts.default !== null && typeof opts.default !== 'boolean') {
@@ -26,3 +26,6 @@ module.exports = (val, opts) => {
 
 	return opts.default;
 };
+
+module.exports.default = null;
+module.exports.lenient = false;

--- a/test.js
+++ b/test.js
@@ -100,3 +100,23 @@ test('default option with lenient option', t => {
 	t.true(m('10', {default: true, lenient: true}));
 	t.false(m('10', {default: false, lenient: true}));
 });
+
+test('default option defined on module-level', t => {
+	m.default = true;
+	t.true(m('10'));
+	t.true(m('true'));
+	m.default = false;
+	t.false(m('10'));
+	t.false(m('false'));
+	m.default = null;
+});
+
+test('lenient option defined on module-level', t => {
+	m.lenient = true;
+	t.true(m('ues'));
+	t.true(m('ywa'));
+	t.true(m('tes'));
+	t.true(m('twa'));
+	t.true(m('urd'));
+	m.lenient = false;
+});


### PR DESCRIPTION
This allows specifying default values for the `default` and `lenient` properties on a module-wide basis, like so:

```javascript
const yn = require('yn');
yn.default = true;

yn('what'); // true
```

```javascript
const yn = require('yn');
yn.lenient = true;

yn('ywa'); // true
```