### PR TITLE
Export default

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,3 +26,5 @@ module.exports = (val, opts) => {
 
 	return opts.default;
 };
+
+module.exports.default = module.exports;

--- a/test.js
+++ b/test.js
@@ -1,6 +1,10 @@
 import test from 'ava';
 import m from '.';
 
+test('default export', t => {
+	t.is(m, m.default);
+});
+
 const truthyCases = [
 	'y',
 	'Y',


### PR DESCRIPTION
this PR will make yn to compatible with ESModule `export default`.
it's convenient to use with TypeScript and other AltJS.

```js
import yn from 'yn'

console.log(yn('yes')) // true
console.log(yn('no'))  // false
```