### PR TITLE
Fix options.default's type being boolean in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Use a key distance-based score to leniently accept typos of `yes` and `no`.
 
 ##### default
 
-Type: `boolean`<br>
+Type: `any`<br>
 Default: `null`
 
 Default value if no match was found.


### PR DESCRIPTION
The default value contradicts the type, as null is not a boolean. This seems to just be a mistake due to copy/pasting without updating the type.