### PR TITLE
Fix Node engine V8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - '12'
   - '10'
+  - '8'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
Fixing Node engine requirements, which is currently set unnecessary high, breaking Node engine V8 compatibility of this module and all it's [dependants](https://github.com/sindresorhus/yn/network/dependents).